### PR TITLE
Update bazel optins to work better with latest bazel (0.4.4)

### DIFF
--- a/com.google.devtools.bazel.e4b/src/com/google/devtools/bazel/e4b/command/BazelCommand.java
+++ b/com.google.devtools.bazel.e4b/src/com/google/devtools/bazel/e4b/command/BazelCommand.java
@@ -56,9 +56,7 @@ public class BazelCommand {
 
   private static final File ASPECT_WORKSPACE = getAspectWorkspace();
   private static final List<String> BUILD_OPTIONS =
-      ImmutableList.of("--experimental_interleave_loading_and_analysis", "--strategy=Javac=worker",
-          "--noexperimental_check_output_files",
-          "--aspects=tools/must/be/unique/e4b_aspect.bzl%e4b_aspect");
+      ImmutableList.of("--watchfs", "--aspects=tools/must/be/unique/e4b_aspect.bzl%e4b_aspect");
   private static final List<String> ASPECT_OPTIONS = ImmutableList
       .<String>builder().addAll(BUILD_OPTIONS).add("-k",
           "--output_groups=ide-info-text,ide-resolve,-_,-defaults", "--experimental_show_artifacts")
@@ -287,7 +285,7 @@ public class BazelCommand {
       File directory, List<String> args, Function<String, String> selector)
           throws IOException, InterruptedException {
     Command command = Command.builder().setConsoleName(getConsoleName(type, directory))
-        .setDirectory(directory).addArguments(bazel.toString(), "--watchfs").addArguments(args)
+        .setDirectory(directory).addArguments(bazel.toString()).addArguments(args)
         .setStdoutLineSelector(selector).build();
     if (command.run() == 0) {
       return command.getSelectedOutputLines();
@@ -299,7 +297,7 @@ public class BazelCommand {
       File directory, List<String> args, Function<String, String> selector)
           throws IOException, InterruptedException {
     Command command = Command.builder().setConsoleName(getConsoleName(type, directory))
-        .setDirectory(directory).addArguments(bazel.toString(), "--watchfs").addArguments(args)
+        .setDirectory(directory).addArguments(bazel.toString()).addArguments(args)
         .setStderrLineSelector(selector).build();
     if (command.run() == 0) {
       return command.getSelectedErrorLines();
@@ -310,7 +308,7 @@ public class BazelCommand {
   private synchronized int runBazel(ConsoleType type, File directory, List<String> args,
       OutputStream stdout, OutputStream stderr) throws IOException, InterruptedException {
     return Command.builder().setConsoleName(getConsoleName(type, directory)).setDirectory(directory)
-        .addArguments(bazel.toString(), "--watchfs").addArguments(args).setStandardOutput(stdout)
+        .addArguments(bazel.toString()).addArguments(args).setStandardOutput(stdout)
         .setStandardError(stderr).build().run();
   }
 


### PR DESCRIPTION
  - `--watchfs` is no longer a startup option
  - Removed now default `--strategy=Javac=worker` and `--experimental_interleave_loading_and_analysis`
  - Removed not useful `--noexperimental_check_output_files`