### PR TITLE
Defines a BazelAspectLocation interface to pass around the location of the aspect workspace

### DIFF
--- a/com.google.devtools.bazel.e4b/src/com/google/devtools/bazel/e4b/command/BazelAspectLocation.java
+++ b/com.google.devtools.bazel.e4b/src/com/google/devtools/bazel/e4b/command/BazelAspectLocation.java
@@ -1,0 +1,29 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.bazel.e4b.command;
+
+import java.io.File;
+
+/**
+ * Define the location of the aspect to use to analyze a Bazel project.
+ */
+public interface BazelAspectLocation {
+
+  /** Returns a {@link File} object that points to the Bazel workspace containing the aspect. */
+  public File getWorkspaceDirectory();
+
+  /** Returns the label of the aspect in the Bazel workspace (with the function name). */
+  public String getAspectLabel();
+}

--- a/com.google.devtools.bazel.e4b/src/com/google/devtools/bazel/e4b/command/BazelAspectLocationImpl.java
+++ b/com.google.devtools.bazel.e4b/src/com/google/devtools/bazel/e4b/command/BazelAspectLocationImpl.java
@@ -1,0 +1,50 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.bazel.e4b.command;
+
+import com.google.devtools.bazel.e4b.Activator;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Platform;
+
+/** Implementation of {@link BazelAspectLocation} using Eclipse OSGi Bundle locations */
+class BazelAspectLocationImpl implements BazelAspectLocation {
+
+  // Returns the path of the resources file from this plugin.
+  private static File getAspectWorkspace() {
+    try {
+      URL url = Platform.getBundle(Activator.PLUGIN_ID).getEntry("resources");
+      URL resolved = FileLocator.resolve(url);
+      return new File(resolved.getPath());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static File WORKSPACE_DIRECTORY = getAspectWorkspace();
+
+  @Override
+  public File getWorkspaceDirectory() {
+    return WORKSPACE_DIRECTORY;
+  }
+
+  @Override
+  public String getAspectLabel() {
+    return "//tools/must/be/unique:e4b_aspect.bzl%e4b_aspect.bzl";
+  }
+
+}


### PR DESCRIPTION
This separate code that depends on Eclipse API from code related to Bazel. A future change
will inject the BazelAspectLocationImpl from another package.