### PR TITLE
Follow the exported java_libraries

### DIFF
--- a/com.google.devtools.bazel.e4b/resources/tools/must/be/unique/e4b_aspect.bzl
+++ b/com.google.devtools.bazel.e4b/resources/tools/must/be/unique/e4b_aspect.bzl
@@ -17,6 +17,7 @@
 DEPENDENCY_ATTRIBUTES = [
   "deps",
   "runtime_deps",
+  "exports",
 ]
 
 def struct_omit_none(**kwargs):


### PR DESCRIPTION
The external libraries exported via java_library were not included in
the build path.