### PR TITLE
Fix broken link in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,5 +25,5 @@ the one above, the
 
 ## Contributing
 
-Please see the [contributing page on the wiki](https://github.com/bazelbuild/eclipse/wiki/Contributing)
+Please see the [Contributing to Bazel](https://bazel.build/contributing.html)
 on more practical matters on how to contribute to e4b.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ site
 
 To import an existing Bazel project or start a new one, go to "New" > "Project..." > "Others".
 
-## Missing features
+## Contributing
 
-See our [contributing page](https://github.com/bazelbuild/eclipse/wiki/Contributing) to get
-some idea on what missing features need help on.
+See our [contributing
+page](https://github.com/bazelbuild/eclipse/blob/master/CONTRIBUTING.md) for how
+to contribute.


### PR DESCRIPTION
Both README.md and CONTRIBUTING.md linked to
`https://github.com/bazelbuild/eclipse/wiki/Contributing` which doesn't
exist.

I didn't find a wiki page that was the obvious intended target, but I tried to fix the broken links.  I don't know if this is how you'd want it fixed.