### PR TITLE
Add release scripts

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,8 +4,7 @@ load(
     "eclipse_feature",
     "eclipse_p2updatesite",
 )
-
-VERSION = "0.0.3.qualifier"
+load(":version.bzl", "VERSION")
 
 eclipse_plugin(
     name = "com.google.devtools.bazel.e4b",
@@ -43,5 +42,6 @@ eclipse_p2updatesite(
     description = "Eclipse plugin for Bazel",
     eclipse_features = [":com.google.devtools.bazel.e4b.feature"],
     label = "Eclipse 4 Bazel",
-    url = "https://bazelbuild.github.io/e4b",
+    url = "https://eclipse.bazel.build",
+    visibility = ["//tools/release:__pkg__"],
 )

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin was tested with Eclipse Mars (4.5) but should also work with Eclipse
    * Select "Help" > "Install Software"
    * Add the update
 site
-[http://bazelbuild.github.io/eclipse/p2updatesite](http://bazelbuild.github.io/eclipse/p2updatesite).
+[https://eclipse.bazel.build/updatesite](https://eclipse.bazel.build/updatesite).
    * Select "Uncategorized category" > "Eclipse 4 Bazel"
 
 ## Using the plugin

--- a/tools/release/BUILD
+++ b/tools/release/BUILD
@@ -1,0 +1,5 @@
+sh_binary(
+    name = "unzip-updatesite",
+    srcs = ["unzip-updatesite.sh"],
+    data = ["//:p2updatesite.zip"],
+)

--- a/tools/release/release.sh
+++ b/tools/release/release.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+ROOTDIR="$(dirname $(dirname "$(cd "$(dirname "$0")" && pwd -P)"))"
+cd "$ROOTDIR"
+RELEASE_ORIGIN=${RELEASE_ORIGIN:-"git@github.com:bazelbuild/eclipse"}
+
+source version.bzl
+# Remove qualifier from VERSION if present
+VERSION="${VERSION//\.qualifier}"
+
+make_version_bzl() {
+  cat <<EOF >version.bzl
+# Note: do not edit, use tools/release/release.sh script instead.
+# This file is both a shell script and a skylark file.
+VERSION="$1"
+EOF
+}
+
+# Create the release tag
+make_release_tag() {
+  # Detach head
+  git checkout -q --detach
+  # Update the version.bzl file
+  make_version_bzl "${VERSION}"
+  # Create the commit
+  git commit -q -m "Release ${VERSION}" version.bzl
+  # Create the tag
+  git tag "${VERSION}"
+  # Checkout back master
+  git checkout -q master
+}
+
+# Create a commit for increasing the version number
+make_release_commit() {
+  git checkout -q master
+  make_version_bzl "${1}.qualifier"
+  git commit -q -m "Update version to ${1}.qualifer after release ${2}" \
+    version.bzl
+}
+
+# Read the version number from the input
+read_version() {
+  while true; do
+    echo -n "$1 [$VERSION] "
+    read ans
+    if [ -n "$ans" ]; then
+      if [[ "$ans" =~ [0-9]+(\.[0-9]+)* ]]; then
+        VERSION="$ans"
+        return
+      else
+        echo "Please enter a version number (e.g. 0.3.0)." >&2
+      fi
+    else
+      return
+    fi
+  done
+}
+
+# Produces all possible new versions
+incr_version() {
+  local v=(${1//./ })
+  for (( i=${#v[@]}-1; $i >= 0; i=$i-1 )); do
+    local new_v=""
+    for (( j=0; $j < ${#v[@]}; j=$j+1 )); do
+      local vj=${v[$j]}
+      if (( $j == $i )); then
+        vj=$(( ${v[$j]} + 1))
+      fi
+      if [ -n "${new_v}" ]; then
+        new_v="${new_v}.${vj}"
+      else
+        new_v="${vj}"
+      fi
+    done
+    echo "${new_v}"
+  done
+}
+
+# Push the master branch and the given tag
+push_master_and_tag() {
+  git push "${RELEASE_ORIGIN}" master
+  git push "${RELEASE_ORIGIN}" "$1"
+}
+
+# Do the release itself, the update site is build on GCCB
+release() {
+  read_version "About to release, which version?"
+  make_release_tag
+  local old_version="${VERSION}"
+  local new_versions=($(incr_version "${VERSION}"))
+  VERSION=${new_versions[0]}
+  echo "Possible versions for next releases: ${new_versions[@]}"
+  read_version "Next version will be?"
+  make_release_commit "${VERSION}" "${old_version}"
+  push_master_and_tag "${old_version}"
+}
+
+release

--- a/tools/release/release.yaml
+++ b/tools/release/release.yaml
@@ -1,0 +1,11 @@
+steps:
+- name: gcr.io/cloud-builders/bazel
+  args: ['run', '//tools/release:unzip-updatesite', '--', '/workspace/bazel-updatesite']
+- name: gcr.io/cloud-builders/gsutil
+  args: ['-m', 'rsync', '-r', '-c', '-d', '/workspace/bazel-updatesite', 'gs://eclipse.bazel.build/updatesite']
+- name: gcr.io/cloud-builders/gsutil
+  args: ['web', 'set', '-m', 'index.html', '-e', '404.html', 'gs://eclipse.bazel.build']
+- name: gcr.io/cloud-builders/gsutil
+  args: ['-m', 'acl', 'ch', '-R', '-u', 'AllUsers:R', 'gs://eclipse.bazel.build']
+
+timeout: 3600s

--- a/tools/release/unzip-updatesite.sh
+++ b/tools/release/unzip-updatesite.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# A small target to run in Google Cloud Container Builder so the result is unzipped.
+
+OUTPUT_DIR="${1:-bazel-updatesite}"
+RUNFILES="${JAVA_RUNFILES:-$0.runfiles}"
+
+unzip -d "${OUTPUT_DIR}" "${RUNFILES}/build_bazel_eclipse/p2updatesite.zip"

--- a/version.bzl
+++ b/version.bzl
@@ -1,0 +1,3 @@
+# Note: do not edit, use tools/release/release.sh script instead.
+# This file is both a shell script and a skylark file.
+VERSION="0.0.3.qualifier"


### PR DESCRIPTION
tools/release/release.sh will now ask for version number and
generates a commit for it. The version number was moved to a
specific bzl file to be easier to manipulate.

tools/release/release.yaml is a Google Cloud Container Builder
script that will build the update site and publish it to eclipse.bazel.build/updatesite

This script only tag a release, it does not mark it as a release
on GitHub yet.